### PR TITLE
This fixes the validation of a PESEL number of '00000000000'

### DIFF
--- a/KZPeselValidator.podspec
+++ b/KZPeselValidator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "KZPeselValidator"
-  s.version      = "0.4"
+  s.version      = "0.3"
   s.summary      = "Validator for Polish national identification number PESEL "
   s.description  = <<-DESC
     Validator for Polish national identification number PESEL

--- a/KZPeselValidator.podspec
+++ b/KZPeselValidator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "KZPeselValidator"
-  s.version      = "0.3"
+  s.version      = "0.4"
   s.summary      = "Validator for Polish national identification number PESEL "
   s.description  = <<-DESC
     Validator for Polish national identification number PESEL

--- a/Sources/KZPeselValidator.swift
+++ b/Sources/KZPeselValidator.swift
@@ -35,7 +35,7 @@ public class KZPeselValidator: KZPeselValidatorType {
             .map({ $0 * $1 })
             .reduce(0, +)
 
-        return methodOneResult % 10 == pesel.checkNumber
+        return methodOneResult != 0 && methodOneResult % 10 == pesel.checkNumber
     }
 
     private func validateWithMethodTwo(pesel: KZPeselType) -> Bool {
@@ -43,6 +43,6 @@ public class KZPeselValidator: KZPeselValidatorType {
             .map({ $0 * $1 })
             .reduce(0, +)
 
-        return methodTwoResult % 10 == 0
+        return methodTwoResult != 0 && methodTwoResult % 10 == 0
     }
 }

--- a/Tests/KZPeselValidatorTests/KZPeselValidatorTests.swift
+++ b/Tests/KZPeselValidatorTests/KZPeselValidatorTests.swift
@@ -25,6 +25,18 @@ class KZPeselValidatorTests: XCTestCase {
         }
     }
 
+    func testThatValidatorReturnInvalidResultForPeselWithAllZeroNumbers() {
+        let incorrectPesel = "00000000000"
+        let sut = KZPeselValidator()
+
+        switch sut.validate(peselNumber: incorrectPesel) {
+        case .valid:
+            XCTFail()
+        case .invalid(let peselNumber):
+            XCTAssertEqual(peselNumber, incorrectPesel)
+        }
+    }
+
     func testThatValidatorReturnValidResultForCorrectPesel() {
         let sut = KZPeselValidator()
 


### PR DESCRIPTION
This pull request fixes the validation of a incorrect PESEL number of '00000000000'. To achieve this, I add a new condition to both methods which validate the PESEL number.